### PR TITLE
set default handler and runtime

### DIFF
--- a/sls-rust.js
+++ b/sls-rust.js
@@ -96,6 +96,8 @@ class SlsRust {
     const artifactPath = join(targetPath, `${projectName}.zip`)
     fn.package = fn.package || {}
     fn.package.artifact = artifactPath
+    fn.handler = 'bootstrap'
+    fn.runtime = 'provided.al2'
     this.log(`Finished building ${projectName}!`)
   }
 


### PR DESCRIPTION
Set the handler to 'bootstrap' after use to find the compiled file and set the runtime to 'provided.al2' by default