### PR TITLE
Fixes to get the plugin working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
    A ⚡ <a href="https://www.serverless.com/framework/docs/">Serverless framework</a> ⚡ plugin for <a href="https://www.rust-lang.org/">Rust</a> applications
 </p>
 
-> Note: this plugin was inspired on [softprops/serverless-rust](https://github.com/softprops/serverless-rust). 
-> Since the `serverless-rust` plugin is not activelly mantained, I created this 
-> one to work with minimal effort as possible: without docker, and probably only 
-> run on Linux (not tested on other OS). Great for CI environments.
+> Note: this plugin was inspired on [softprops/serverless-rust](https://github.com/softprops/serverless-rust).
+> Since the `serverless-rust` plugin is not actively mantained, I created this
+> one to work with minimal effort as possible: without docker, and probably only
+> run on Linux and macOS (not tested on other OS). Great for CI environments.
 
 ## 📦 Install
+
+Install [Zig](https://ziglang.org/) and [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) because this plugin uses Zig as a linker for easier cross-compiling.
 
 You should put the `serverless.yml` file outside the Rust project directory:
 
@@ -112,6 +114,6 @@ $ npx serverless invoke -f hello -d '{"hello":"world"}'
 $ npx serverless logs -f hello
 ```
 
-## License 
+## License
 
 MIT

--- a/sls-rust.js
+++ b/sls-rust.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { spawn } = require('node:child_process')
+const { existsSync, mkdirSync } = require('node:fs')
 const { join } = require('node:path')
 
 class SlsRust {
@@ -55,14 +56,29 @@ class SlsRust {
 
   }
 
-  async runBuildCommand ({ path, projectName }) {
+  createTargetPath(targetPath) {
+    if (!existsSync(targetPath)) {
+      mkdirSync(targetPath, { recursive: true });
+    }
+  }
+
+  async runBuildCommand ({ projectName }) {
     try {
-      await this.runCommand({ 
-        command: `cargo build --release --target ${this.targetRuntime}`, 
-        cwd: path,
+      await this.runCommand({
+        command: `cargo zigbuild --release --target ${this.targetRuntime}`,
       })
     } catch (error) {
       throw new Error(`Error building project ${projectName}: ${error}`)
+    }
+  }
+
+  async moveBinaryToTargetPath ({ targetPath, projectName }) {
+    try {
+      await this.runCommand({
+        command: `mv target/${this.targetRuntime}/release/${projectName} ${targetPath}`,
+      })
+    } catch (error) {
+      throw new Error(`Error moving binary to target path ${targetPath}: ${error}`)
     }
   }
 
@@ -89,8 +105,12 @@ class SlsRust {
     const { projectPath, projectName } = this.getProjectPathAndName(fn)
     this.log(`Building Rust ${fn.handler} func...`)
     const path = join('.', projectPath)
-    const targetPath = join(path, 'target', this.targetRuntime, 'release')
-    await this.runBuildCommand({ path, projectName })
+
+    const targetPath = join('target', path, this.targetRuntime, 'release')
+    this.createTargetPath(targetPath)
+
+    await this.runBuildCommand({ projectName })
+    await this.moveBinaryToTargetPath({ targetPath, projectName })
     await this.runZipArtifact({ path: targetPath, projectName })
 
     const artifactPath = join(targetPath, `${projectName}.zip`)

--- a/sls-rust.js
+++ b/sls-rust.js
@@ -97,7 +97,7 @@ class SlsRust {
       await this.runCommand({ command: `zip -j ${projectFullPath}.zip ${bootstrapFullPath}`, cwd: path })
       await this.runCommand({ command: `mv ${projectFullPath}.zip .`, cwd: path })
     } catch (error) {
-      throw new Error(`Error trying to zip artefact in ${projectName}: ${error}`)
+      throw new Error(`Error trying to zip artifact in ${projectName}: ${error}`)
     }
   }
 


### PR DESCRIPTION
Hello, I ran into deployment issues when I was trying to deploy a Rust function from my Macbook. I'd love to get your feedback on whether these changes make sense or I was using it wrong to being with.

Also, I don't have a Linux machine to test these changes on, so some testing on your side would be much appreciated.

### First issue

```shell
Deploying your dev env to AWS
sls deploy --stage k1
Running "serverless" from node_modules

Deploying test-rust to stage k1 (us-east-1)
Building Rust my-project1.test-func func...

✖ Stack test-rust-k1 failed to deploy (8s)
Environment: darwin, node 18.16.0, framework 3.33.0 (local) 3.31.0v (global), plugin 6.2.3, SDK 4.3.2
Credentials: Local, "default" profile
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Error: Error trying to zip artefact in test-func: Error: spawn rm ENOENT
    at SlsRust.runZipArtifact (/code/libs/sls-rust/sls-rust.js:84:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async SlsRust.build (/code/libs/sls-rust/sls-rust.js:94:5)
    at async Promise.all (index 0)
    at async SlsRust.buildPrepare (/code/libs/sls-rust/sls-rust.js:40:5)
    at async PluginManager.runHooks (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:530:9)
    at async PluginManager.invoke (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:563:9)
    at async PluginManager.spawn (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:585:5)
    at async before:deploy:deploy (/code/test-rust/node_modules/serverless/lib/plugins/deploy.js:40:11)
    at async PluginManager.runHooks (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:530:9)
    at async PluginManager.invoke (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:563:9)
    at async PluginManager.run (/code/test-rust/node_modules/serverless/lib/classes/plugin-manager.js:604:7)
    at async Serverless.run (/code/test-rust/node_modules/serverless/lib/serverless.js:179:5)
    at async /code/test-rust/node_modules/serverless/scripts/serverless.js:834:9
error: Recipe `deploy` failed on line 28 with exit code 1
```

I dug into the source code a bit and the main issue I found was that Cargo defaults to building the binary in the root `target/`, but this plugin tries to build in `<project-dir>/target`. I propose that we fix this by building everything in the root `target/` directory.

### Second issue

I also ran into an issue with the linker:

```shell
WARN rustc_codegen_ssa::back::link Linker does not support -static-pie command line option. Retrying with -static instead.
error: linking with `cc` failed: exit status: 1
```

I was able to fix this by switching to [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild) as a linker.